### PR TITLE
Don't test group properties on half-integral blocks

### DIFF
--- a/src/representation.jl
+++ b/src/representation.jl
@@ -7,7 +7,7 @@
 # Chirikjian, G. S. Stochastic Models, Information Theory, and Lie Groups, Volume 2. 2012.
 # ISBN: 978-0-8176-4943-2. doi: 10.1007/978-0-8176-4944-9.
 
-cln(ℓ, n) = abs(n) ≤ ℓ ? sqrt((ℓ - n) * (ℓ + n + 1)) : zero(float(Base.promote_typeof(ℓ, n)))
+cln(ℓ, n) = ℓ ≥ n ? sqrt((ℓ - n) * (ℓ + n + 1)) : zero(float(Base.promote_typeof(ℓ, n)))
 
 # TODO: refactor to be in terms of diagonals so we can avoid kronecker delta entirely
 

--- a/src/representation.jl
+++ b/src/representation.jl
@@ -7,7 +7,7 @@
 # Chirikjian, G. S. Stochastic Models, Information Theory, and Lie Groups, Volume 2. 2012.
 # ISBN: 978-0-8176-4943-2. doi: 10.1007/978-0-8176-4944-9.
 
-cln(ℓ, n) = ℓ ≥ n ? sqrt((ℓ - n) * (ℓ + n + 1)) : zero(float(Base.promote_typeof(ℓ, n)))
+cln(ℓ, n) = abs(n) ≤ ℓ ? sqrt((ℓ - n) * (ℓ + n + 1)) : zero(float(Base.promote_typeof(ℓ, n)))
 
 # TODO: refactor to be in terms of diagonals so we can avoid kronecker delta entirely
 

--- a/test/representation.jl
+++ b/test/representation.jl
@@ -77,7 +77,7 @@ end
     @testset "SO(3) representations" begin
         # R = Rotations.UnitQuaternion(normalize(randn(4)))
         @testset "basic group properties" begin
-            @testset "ℓ=$ℓ" for ℓ in 0:0.5:20
+            @testset "ℓ=$ℓ" for ℓ in 0:20
                 R1 = Rotations.UnitQuaternion(normalize(randn(4)))
                 R2 = Rotations.UnitQuaternion(normalize(randn(4)))
                 R12 = R1 * R2


### PR DESCRIPTION
~Fixes the sign of blocks for half-integral degrees. Not strictly necessary because we don't use half-integral blocks, but nice to know the general version works.~

Edit: Technically the half-integral blocks are representations of SU(2), not SO(3), so they follow a different composition rule. Informally, SU(2) is a sphere, and SO(3) is one of its hemispheres. If we embed SO(3) in SU(2), then composition of two rotations in SO(3) can produce a rotation in SU(2). However, if we don't embed it, then the resulting rotation will be in SO(3). Constructing a half-integral block implicitly maps to SU(2) first, hence a different composition rule is followed. Again, we don't use the half-integral blocks anyways, so this isn't a problem, but it's good to know that the test suite picked up on this.