### PR TITLE
Refactor so(3) representations to compute diagonals directly

### DIFF
--- a/src/representation.jl
+++ b/src/representation.jl
@@ -7,8 +7,6 @@
 # Chirikjian, G. S. Stochastic Models, Information Theory, and Lie Groups, Volume 2. 2012.
 # ISBN: 978-0-8176-4943-2. doi: 10.1007/978-0-8176-4944-9.
 
-
-
 # diagonals of infinitesimal rotation elements of Varshalovich §4.18.3.
 function representation_diag(::typeof(so3), ::typeof(E1), ℓ, ::Val{i}) where {i}
     ℓ2 = Int(2ℓ)

--- a/test/representation.jl
+++ b/test/representation.jl
@@ -49,7 +49,11 @@ end
             @testset "ℓ=$ℓ" for ℓ in 1:0.5:100
                 u_Ei = @inferred representation_block(so3, Ei, ℓ)
                 u_Eimat = @inferred representation_block(so3, Eimat, ℓ)
-                @test u_Ei isa Tridiagonal
+                if Ei === E3
+                    @test u_Ei isa Diagonal
+                else
+                    @test u_Ei isa Tridiagonal
+                end
                 @test u_Eimat isa Tridiagonal
                 @test isskewhermitian(u_Ei)
                 @test isskewhermitian(u_Eimat)


### PR DESCRIPTION
We were already computing diagonals, but in terms of the elements, which included a condition check for whether this was a diagonal. Now everything is in terms of diagonals.