### PR TITLE
Bump Rotations supported version to v1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Distributions = "0.24"
 Manifolds = "0.4"
 PDMats = "0.10"
-Rotations = "1"
+Rotations = "1.1"
 StatsBase = "0.33"
 julia = "1"
 

--- a/test/representation.jl
+++ b/test/representation.jl
@@ -104,11 +104,11 @@ end
     end
 
     @testset "SO(3) representations" begin
-        # R = Rotations.UnitQuaternion(normalize(randn(4)))
+        # R = Rotations.QuatRotation(normalize(randn(4)))
         @testset "basic group properties" begin
             @testset "ℓ=$ℓ" for ℓ in 0:20
-                R1 = Rotations.UnitQuaternion(normalize(randn(4)))
-                R2 = Rotations.UnitQuaternion(normalize(randn(4)))
+                R1 = Rotations.QuatRotation(normalize(randn(4)))
+                R2 = Rotations.QuatRotation(normalize(randn(4)))
                 R12 = R1 * R2
                 # identity
                 Ue = @inferred representation_block(SO3, Matrix{Float64}(I, 3, 3), ℓ)


### PR DESCRIPTION
This PR replaces the now-deprecated `UnitQuaternion` with `QuatRotation`.